### PR TITLE
ci: add per-job timeouts + cache Playwright browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   Lint:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v5
@@ -18,6 +19,7 @@ jobs:
 
   Test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v5
@@ -26,9 +28,25 @@ jobs:
 
   E2ETests:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
-      - run: npx playwright install chromium
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -e "console.log(require('@playwright/test/package.json').version)")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
       - run: pnpm test:e2e

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   Deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     environment:
       name: ${{ github.ref_name == 'main' && 'production' || 'preview' }}
       url: ${{ steps.deploy.outputs.deployment-url }}


### PR DESCRIPTION
## Summary

- Add `timeout-minutes:` to every job so a hung step fails fast instead of burning runner minutes against the 6h default: `Lint` 10, `Test` 10, `E2ETests` 20 (ci.yml), `Deploy` 15 (deploy.yml).
- Cache Playwright browsers (`~/.cache/ms-playwright`) in `E2ETests` via `actions/cache`, keyed on `runner.os` + the installed `@playwright/test` version (read from `node_modules` after `pnpm install`, so it tracks the lockfile). `npx playwright install --with-deps chromium` runs only on cache miss; on a hit the download is skipped entirely.

The Deploy job's sticky PR-comment steps are untouched.

## Test plan

- [x] YAML parses (validated locally)
- [ ] CI on this PR: first `E2ETests` run populates the cache and passes; a subsequent run restores the cache and skips the install step