### PR TITLE
fix(GameBoard): survive focus loss by listening for arrow keys on window

### DIFF
--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import { AnimatePresence } from "motion/react";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 import type { Direction, TileState } from "../hooks/useGame2048";
 import { Tile } from "./Tile";
@@ -22,29 +22,24 @@ const keyDirectionMap: Record<string, Direction> = {
 };
 
 export const GameBoard = ({ grid, tiles, onMove }: GameBoardProps) => {
-  const boardRef = useRef<HTMLDivElement>(null);
-
   useEffect(() => {
-    boardRef.current?.focus();
-  }, []);
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const direction = keyDirectionMap[event.key];
+      if (direction) {
+        event.preventDefault();
+        onMove(direction);
+      }
+    };
 
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    const direction = keyDirectionMap[event.key];
-    if (direction) {
-      event.preventDefault();
-      onMove(direction);
-    }
-  };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onMove]);
 
   return (
     <div
-      ref={boardRef}
-      tabIndex={0}
-      onKeyDown={handleKeyDown}
       className={clsx(
         "relative aspect-square w-[90vw] max-w-[500px]",
         "touch-none rounded-lg bg-gray-700 select-none",
-        "ring-blue-500 outline-none focus:ring-4",
       )}
       style={{ touchAction: "none" }}
       role="grid"


### PR DESCRIPTION
## Summary

Clicking the **Reset Game** / **New Game** button moves focus to that button. Arrow-key handling lived in an `onKeyDown` handler on the board div, which only receives key events while the div itself has focus — so after a reset the game appeared unresponsive until the board was clicked again.

This PR moves the arrow-key listener to a `window` `keydown` listener registered in a `useEffect` (with cleanup), so arrow keys work regardless of which element currently has focus. `preventDefault` on arrow keys is preserved, so the page still doesn't scroll while playing. The focus plumbing that existed only to support the old approach (`boardRef` + mount-time `focus()`, `tabIndex`, focus-ring styles) became dead code and is removed.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint .` passes
- [x] `vitest run` passes (21 tests)
- [x] `vite build` passes
- [ ] Manual: click Reset Game, then press an arrow key → the board still moves