### PR TITLE
a11y: fix invalid ARIA roles + add aria-live for score and game-state

### DIFF
--- a/e2e-tests/index.spec.js
+++ b/e2e-tests/index.spec.js
@@ -13,7 +13,7 @@ test("should load the 2048 game", async ({ page }) => {
   await expect(page.getByText("Score: 0")).toBeVisible();
 
   // Check that the game board is present
-  const gameBoard = page.getByRole("grid");
+  const gameBoard = page.getByRole("application");
   await expect(gameBoard).toBeVisible();
 
   // Check that tiles are present in the game board
@@ -35,7 +35,7 @@ test("should handle game interactions", async ({ page }) => {
   const initialScore = parseInt(scoreText.match(/\d+/)[0]);
 
   // Simulate a swipe (drag) gesture
-  const gameBoard = page.getByRole("grid");
+  const gameBoard = page.getByRole("application");
   const box = await gameBoard.boundingBox();
 
   // Swipe left
@@ -57,7 +57,7 @@ test("should reset the game", async ({ page }) => {
   await page.goto("/");
 
   // Make some moves first
-  const gameBoard = page.getByRole("grid");
+  const gameBoard = page.getByRole("application");
   const box = await gameBoard.boundingBox();
 
   // Swipe in different directions
@@ -78,27 +78,22 @@ test("should reset the game", async ({ page }) => {
 test("tiles remain square and aligned", async ({ page }) => {
   await page.goto("/");
 
-  const board = page.getByRole("grid");
+  const board = page.getByRole("application");
   await expect(board).toBeVisible();
 
   const tileSnapshot = await board.evaluate((boardElement) => {
-    const tilesLayer = boardElement.querySelector('[role="group"]');
-    if (!tilesLayer) {
-      return null;
-    }
-
     const boardRect = boardElement.getBoundingClientRect();
     // Use offsetWidth/Height (layout box, ignores transform) instead of
     // getBoundingClientRect (transform-aware) so in-flight scale animations
     // don't perturb the measurements this test cares about.
-    const tiles = Array.from(
-      tilesLayer.querySelectorAll('[role="gridcell"]'),
-    ).map((tile) => ({
-      width: tile.offsetWidth,
-      height: tile.offsetHeight,
-      rowStart: Number.parseInt(tile.style.gridRowStart ?? "0", 10),
-      colStart: Number.parseInt(tile.style.gridColumnStart ?? "0", 10),
-    }));
+    const tiles = Array.from(boardElement.querySelectorAll('[role="img"]')).map(
+      (tile) => ({
+        width: tile.offsetWidth,
+        height: tile.offsetHeight,
+        rowStart: Number.parseInt(tile.style.gridRowStart ?? "0", 10),
+        colStart: Number.parseInt(tile.style.gridColumnStart ?? "0", 10),
+      }),
+    );
 
     return {
       boardWidth: boardRect.width,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,13 +31,13 @@ const App = () => {
     <div className="flex h-screen min-h-screen items-center justify-center overflow-hidden bg-gray-900 text-white">
       <div className="flex flex-col items-center gap-4 px-4 sm:gap-6 md:gap-8">
         <div className="text-center">
-          <h1
-            role="game-title"
-            className="mb-2 text-[10vw] font-bold sm:mb-4 sm:text-5xl md:text-6xl"
-          >
+          <h1 className="mb-2 text-[10vw] font-bold sm:mb-4 sm:text-5xl md:text-6xl">
             2048
           </h1>
-          <div className="mb-2 text-[5vw] sm:mb-4 sm:text-xl md:text-2xl">
+          <div
+            aria-live="polite"
+            className="mb-2 text-[5vw] sm:mb-4 sm:text-xl md:text-2xl"
+          >
             Score: {score}
           </div>
         </div>
@@ -58,6 +58,7 @@ const App = () => {
           {(gameOver || won) && (
             <motion.div
               key="game-state-overlay"
+              aria-live="polite"
               className="text-center"
               initial={{ opacity: 0, scale: 0.8, y: -8 }}
               animate={{ opacity: 1, scale: 1, y: 0 }}

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -47,7 +47,8 @@ export const GameBoard = ({ grid, tiles, onMove }: GameBoardProps) => {
         "ring-blue-500 outline-none focus:ring-4",
       )}
       style={{ touchAction: "none" }}
-      role="grid"
+      role="application"
+      aria-label="2048 game board"
     >
       <div className={clsx(gridClasses, "h-full")}>
         {grid.flat().map((_, i) => (
@@ -61,7 +62,6 @@ export const GameBoard = ({ grid, tiles, onMove }: GameBoardProps) => {
       </div>
 
       <div
-        role="group"
         className={clsx(
           "pointer-events-none absolute inset-0 h-full",
           gridClasses,

--- a/src/components/Tile.tsx
+++ b/src/components/Tile.tsx
@@ -80,7 +80,8 @@ export const Tile = ({ tile, style }: TileProps) => {
         // arriving at the merge cell.
         zIndex: isGhost === true ? 0 : isMerged ? 2 : 1,
       }}
-      role="gridcell"
+      role="img"
+      aria-label={`Tile with value ${value}`}
       initial={{
         opacity: isNew ? 0 : 1,
         scale: isNew ? 0.5 : 1,


### PR DESCRIPTION
## Summary

Fixes ARIA correctness bugs and adds live-region announcements:

- Removed the invalid `role="game-title"` from the `<h1>` — not a valid ARIA role; the heading alone is correct.
- The board's `role="grid"` was structurally invalid (`grid` requires `row` descendants with `gridcell` children; tiles sat inside a `role="group"` instead). The board container is now `role="application"` with `aria-label="2048 game board"`, and the intermediate `role="group"` wrapper is dropped.
- Tiles changed from `role="gridcell"` to `role="img"` with `aria-label="Tile with value {value}"`, giving each tile a self-describing node in the a11y tree.
- Added `aria-live="polite"` to the score display and the Game Over / You Win overlay so screen readers announce changes.
- Updated E2E selectors to match the new roles (`grid` → `application`, `gridcell` → `img`, removed the `group` layer lookup).

## Test plan

- [x] `pnpm run lint` (eslint / tsc / prettier) passes
- [x] `pnpm run test` (vitest, 21 tests) passes
- [x] `pnpm run build` (tsc + vite build) passes
- [x] `pnpm run test:e2e` (playwright, 4 tests) passes with the updated role selectors