### PR TITLE
chore: drop dead grid prop + typecheck root config files

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,7 @@ import { GameBoard } from "./components/GameBoard";
 import { useGame2048 } from "./hooks/useGame2048";
 
 const App = () => {
-  const { grid, tiles, score, gameOver, won, makeMove, resetGame } =
-    useGame2048();
+  const { tiles, score, gameOver, won, makeMove, resetGame } = useGame2048();
 
   const handleSwipe = useCallback(
     (_event: PointerEvent | MouseEvent | TouchEvent, info: PanInfo) => {
@@ -51,7 +50,7 @@ const App = () => {
           onPanEnd={handleSwipe}
           style={{ touchAction: "none" }}
         >
-          <GameBoard grid={grid} tiles={tiles} onMove={makeMove} />
+          <GameBoard tiles={tiles} onMove={makeMove} />
         </motion.div>
 
         <AnimatePresence>

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -6,10 +6,11 @@ import type { Direction, TileState } from "../hooks/useGame2048";
 import { Tile } from "./Tile";
 
 interface GameBoardProps {
-  grid: number[][];
   tiles: TileState[];
   onMove: (direction: Direction) => void;
 }
+
+const CELL_COUNT = 16;
 
 const gridClasses =
   "grid grid-cols-4 grid-rows-4 gap-[2vw] p-[2vw] sm:gap-3 sm:p-3 md:gap-4 md:p-4";
@@ -21,7 +22,7 @@ const keyDirectionMap: Record<string, Direction> = {
   ArrowRight: "right",
 };
 
-export const GameBoard = ({ grid, tiles, onMove }: GameBoardProps) => {
+export const GameBoard = ({ tiles, onMove }: GameBoardProps) => {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       const direction = keyDirectionMap[event.key];
@@ -45,7 +46,7 @@ export const GameBoard = ({ grid, tiles, onMove }: GameBoardProps) => {
       role="grid"
     >
       <div className={clsx(gridClasses, "h-full")}>
-        {grid.flat().map((_, i) => (
+        {Array.from({ length: CELL_COUNT }, (_, i) => (
           <div
             key={i}
             aria-hidden="true"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,11 +14,16 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
-    "types": ["vitest/globals"],
+    "types": ["vitest/globals", "node"],
     "paths": {
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"],
+  "include": [
+    "src",
+    "vite.config.ts",
+    "vitest.config.ts",
+    "playwright.config.ts"
+  ],
   "exclude": ["node_modules", "e2e-tests"]
 }


### PR DESCRIPTION
## Summary

Two code-hygiene changes, no behaviour change:

**Drop dead `grid` prop plumbing**
- `GameBoard` only used `grid` to render 16 placeholder cells (`grid.flat().map((_, i) => …)` ignored the values), so the prop was dead weight. The placeholders now render via `Array.from({ length: CELL_COUNT }, …)` and the prop is removed from `GameBoardProps` / `App.tsx`.
- The `grid` memo on `useGame2048` is kept as-is (tests consume it).

**Type-check root config files**
- `tsconfig.json` previously included only `src`, so `vite.config.ts` / `vitest.config.ts` / `playwright.config.ts` were never type-checked. They are now added to `include`, with `node` added to `types` for the Node globals they use (`__dirname`, `process`).
- This keeps the existing `tsc --noEmit` / `tsc && vite build` scripts and the eslint `project: true` setup working unchanged, avoiding the project-references restructure.

## Test plan

- [x] `pnpm exec tsc --noEmit` passes (verified the 3 config files now appear in `--listFiles`)
- [x] `pnpm exec eslint .` passes
- [x] `pnpm run test` — 21 tests pass
- [x] `pnpm run build` (tsc + vite build) passes
- [x] `pnpm exec prettier --check .` passes