### PR TITLE
a11y: honour prefers-reduced-motion + allow pinch-zoom (WCAG 1.4.4)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta
-      name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
-    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>2048 Game</title>
   </head>
   <body>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import "@/styles/globals.css";
 
+import { MotionConfig } from "motion/react";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
@@ -7,6 +8,8 @@ import App from "@/App";
 
 createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>
-    <App />
+    <MotionConfig reducedMotion="user">
+      <App />
+    </MotionConfig>
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary

Two accessibility improvements:

- **Honour `prefers-reduced-motion`**: wrap the app in `<MotionConfig reducedMotion="user">` so motion animations respect the OS "reduce motion" preference (transform/opacity animations become instant/minimal).
- **Fix WCAG 1.4.4 (Resize text) viewport violation**: drop `maximum-scale=1.0, user-scalable=no` from the viewport meta tag to re-enable pinch-zoom. The game board already sets `touch-action: none` on its interactive surface, so page-level zoom does not fight swipe gameplay.

## Test plan

- [ ] `pnpm dev` → DevTools → Rendering → emulate `prefers-reduced-motion: reduce` → confirm tile moves are instant (or near-instant)
- [ ] On a touch device (or DevTools device emulation), confirm pinch-zoom works on the page while board swipes still control the game

Nothing beyond CI otherwise (lint / type-check / tests / build all pass locally).