### PR TITLE
perf: shrink bundle via LazyMotion + m-components (feature loading)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import type { PanInfo } from "motion/react";
-import { AnimatePresence, motion } from "motion/react";
+import { AnimatePresence, m } from "motion/react";
 import { useCallback } from "react";
 
 import { GameBoard } from "./components/GameBoard";
@@ -41,7 +41,7 @@ const App = () => {
           </div>
         </div>
 
-        <motion.div
+        <m.div
           drag
           dragConstraints={{ top: 0, bottom: 0, left: 0, right: 0 }}
           dragElastic={0}
@@ -51,11 +51,11 @@ const App = () => {
           style={{ touchAction: "none" }}
         >
           <GameBoard tiles={tiles} onMove={makeMove} />
-        </motion.div>
+        </m.div>
 
         <AnimatePresence>
           {(gameOver || won) && (
-            <motion.div
+            <m.div
               key="game-state-overlay"
               aria-live="polite"
               className="text-center"
@@ -79,7 +79,7 @@ const App = () => {
               >
                 New Game
               </button>
-            </motion.div>
+            </m.div>
           )}
         </AnimatePresence>
 

--- a/src/components/Tile.tsx
+++ b/src/components/Tile.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { motion } from "motion/react";
+import { m } from "motion/react";
 import type { CSSProperties } from "react";
 
 import type { TileState } from "../hooks/useGame2048";
@@ -66,7 +66,7 @@ export const Tile = ({ tile, style }: TileProps) => {
       : { scale: 1, opacity: 1 };
 
   return (
-    <motion.div
+    <m.div
       layout
       className={clsx(
         "flex h-full w-full items-center justify-center",
@@ -91,6 +91,6 @@ export const Tile = ({ tile, style }: TileProps) => {
       transition={MOVE_TRANSITION}
     >
       {value}
-    </motion.div>
+    </m.div>
   );
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,15 +1,20 @@
 import "@/styles/globals.css";
 
-import { MotionConfig } from "motion/react";
+import { LazyMotion, MotionConfig } from "motion/react";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import App from "@/App";
 
+const loadMotionFeatures = () =>
+  import("@/motionFeatures").then((module) => module.default);
+
 createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>
     <MotionConfig reducedMotion="user">
-      <App />
+      <LazyMotion features={loadMotionFeatures} strict>
+        <App />
+      </LazyMotion>
     </MotionConfig>
   </StrictMode>,
 );

--- a/src/motionFeatures.ts
+++ b/src/motionFeatures.ts
@@ -1,0 +1,7 @@
+import { domMax } from "motion/react";
+
+// Loaded lazily by <LazyMotion> in main.tsx so the animation feature
+// implementation is code-split out of the initial bundle. domMax (not
+// domAnimation) because the app uses `layout` (tile slides) and `drag`
+// (swipe input) — both are domMax-only features.
+export default domMax;


### PR DESCRIPTION
## Summary

Shrinks the initial production bundle by switching from full `motion` component imports to `LazyMotion` + `m` components with an async-loaded feature bundle.

- `motion.div` → `m.div` in `Tile.tsx`, `GameBoard.tsx`'s children, and `App.tsx`
- App root wrapped in `<LazyMotion features={loadMotionFeatures} strict>` in `main.tsx`
- Feature bundle is `domMax` (not `domAnimation`) because the app uses `layout` animations (tile slides) and `drag` gestures (swipe input) — both are `domMax`-only
- `domMax` is exported from `src/motionFeatures.ts` and loaded via dynamic `import()`, so Vite code-splits it out of the initial chunk; `strict` guards against accidental full-`motion` reintroduction

## Bundle size

| | Before | After | Delta |
|---|---|---|---|
| `index-*.js` | 322.58 kB | 242.84 kB | **-79.74 kB (-24.7%)** |
| `index-*.js` (gzip) | 103.12 kB | 79.24 kB | **-23.88 kB (-23.2%)** |
| `motionFeatures-*.js` (async) | — | 83.57 kB / gzip 27.39 kB | loaded after initial render |

Note: total JS across chunks is roughly unchanged (+~4 kB) — the win is the initial-load payload, which drops ~24%. The `domMax` chunk loads in parallel after first paint.

## Test plan

- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm exec eslint .` passes
- [x] `pnpm exec vitest run` passes (21 tests)
- [x] `pnpm exec vite build` passes; sizes above
- [x] Playwright smoke test against `pnpm dev`: 8 arrow-key moves — tiles merged (2→4→8), a non-identity transform was observed mid-animation on every move (layout slide + pop active), zero console errors/warnings (`strict` mode did not fire)
