### PR TITLE
test(e2e): strengthen assertions + add Mobile Chrome project

### DIFF
--- a/e2e-tests/index.spec.ts
+++ b/e2e-tests/index.spec.ts
@@ -1,20 +1,24 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
-const readScore = async (page: Page): Promise<number> => {
-  const scoreText = await page.getByText(/Score: \d+/).textContent();
-  const match = scoreText?.match(/\d+/);
-  if (!match) throw new Error(`score text not found: ${String(scoreText)}`);
-  return Number.parseInt(match[0], 10);
-};
+import type { SwipeDirection } from "./utils";
+import { expectSwipeToChangeBoard } from "./utils";
 
-const swipeLeft = async (page: Page, gameBoard: Locator): Promise<void> => {
+const mouseSwipe = async (
+  page: Page,
+  gameBoard: Locator,
+  direction: SwipeDirection,
+): Promise<void> => {
   const box = await gameBoard.boundingBox();
   if (!box) throw new Error("game board has no bounding box");
 
-  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  const startX = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+  const endX = direction === "left" ? box.x + 50 : box.x + box.width - 50;
+
+  await page.mouse.move(startX, y);
   await page.mouse.down();
-  await page.mouse.move(box.x + 50, box.y + box.height / 2);
+  await page.mouse.move(endX, y, { steps: 5 });
   await page.mouse.up();
 };
 
@@ -34,9 +38,10 @@ test("should load the 2048 game", async ({ page }) => {
   const gameBoard = page.getByRole("application");
   await expect(gameBoard).toBeVisible();
 
-  // Check that tiles are present in the game board
+  // Check that the placeholder cells and the two starting tiles are present
   const cells = gameBoard.locator('[role="presentation"]');
   await expect(cells).toHaveCount(16); // 4x4 grid placeholders
+  await expect(gameBoard.locator('[role="img"]')).toHaveCount(2);
 
   // Check reset button is visible
   await expect(page.getByRole("button", { name: "Reset Game" })).toBeVisible();
@@ -45,37 +50,31 @@ test("should load the 2048 game", async ({ page }) => {
   await expect(page.getByText("Swipe or use arrow keys to play")).toBeVisible();
 });
 
-test("should handle game interactions", async ({ page }) => {
+test("swipe moves tiles on the board", async ({ page }) => {
   await page.goto("/");
 
-  const initialScore = await readScore(page);
-
-  // Simulate a swipe (drag) gesture
   const gameBoard = page.getByRole("application");
-  await swipeLeft(page, gameBoard);
+  await expect(gameBoard.locator('[role="img"]')).toHaveCount(2);
 
-  // Wait a bit for the game to update
-  await page.waitForTimeout(300);
-
-  // Score might have changed if tiles merged
-  const newScore = await readScore(page);
-  expect(newScore).toBeGreaterThanOrEqual(initialScore);
+  // A successful move must change the board (tiles shift and a new one
+  // spawns) — assert on the serialized board, not on the score, which is
+  // monotonic and passes even when movement is broken.
+  await expectSwipeToChangeBoard(page, gameBoard, mouseSwipe);
 });
 
 test("should reset the game", async ({ page }) => {
   await page.goto("/");
 
-  // Make some moves first
+  // Make a move that verifiably changed the board first
   const gameBoard = page.getByRole("application");
-  await swipeLeft(page, gameBoard);
-
-  await page.waitForTimeout(200);
+  await expectSwipeToChangeBoard(page, gameBoard, mouseSwipe);
 
   // Click reset button
   await page.getByRole("button", { name: "Reset Game" }).click();
 
-  // Score should be back to 0
+  // Score should be back to 0 and the board back to the two starting tiles
   await expect(page.getByText("Score: 0")).toBeVisible();
+  await expect(gameBoard.locator('[role="img"]')).toHaveCount(2);
 });
 
 test("tiles remain square and aligned", async ({ page }) => {

--- a/e2e-tests/mobile.spec.ts
+++ b/e2e-tests/mobile.spec.ts
@@ -1,0 +1,54 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import type { SwipeDirection } from "./utils";
+import { expectSwipeToChangeBoard } from "./utils";
+
+/**
+ * Drive a swipe with real touch input via CDP so the touch → pointer event
+ * cascade the mobile swipe UX depends on is exercised end-to-end.
+ * Chromium-only, which both configured projects satisfy.
+ */
+const touchSwipe = async (
+  page: Page,
+  gameBoard: Locator,
+  direction: SwipeDirection,
+): Promise<void> => {
+  const box = await gameBoard.boundingBox();
+  if (!box) throw new Error("game board has no bounding box");
+
+  const startX = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+  const step = (direction === "left" ? -1 : 1) * 20;
+
+  const cdp = await page.context().newCDPSession(page);
+  try {
+    await cdp.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [{ x: startX, y }],
+    });
+    for (let i = 1; i <= 5; i += 1) {
+      await cdp.send("Input.dispatchTouchEvent", {
+        type: "touchMove",
+        touchPoints: [{ x: startX + i * step, y }],
+      });
+    }
+    await cdp.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [],
+    });
+  } finally {
+    await cdp.detach();
+  }
+};
+
+test("touch swipe moves tiles on the board", async ({ page, isMobile }) => {
+  test.skip(!isMobile, "touch swipe is exercised on the mobile project only");
+
+  await page.goto("/");
+
+  const gameBoard = page.getByRole("application");
+  await expect(gameBoard.locator('[role="img"]')).toHaveCount(2);
+
+  await expectSwipeToChangeBoard(page, gameBoard, touchSwipe);
+});

--- a/e2e-tests/utils.ts
+++ b/e2e-tests/utils.ts
@@ -1,0 +1,49 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+export type SwipeDirection = "left" | "right";
+
+export type Swipe = (
+  page: Page,
+  gameBoard: Locator,
+  direction: SwipeDirection,
+) => Promise<void>;
+
+/**
+ * Serialize the board into a deterministic "row,col:label" string so
+ * before/after comparisons detect any tile movement, merge, or spawn.
+ */
+export const serializeBoard = async (gameBoard: Locator): Promise<string> =>
+  gameBoard.evaluate((boardElement) =>
+    Array.from(boardElement.querySelectorAll<HTMLElement>('[role="img"]'))
+      .map(
+        (tile) =>
+          `${tile.style.gridRowStart},${tile.style.gridColumnStart}:${
+            tile.getAttribute("aria-label") ?? ""
+          }`,
+      )
+      .sort()
+      .join("|"),
+  );
+
+/**
+ * Swipe left and assert the board actually changed. If the left swipe was a
+ * no-op (both starting tiles already sat in the leftmost column), a right
+ * swipe is guaranteed to move them, so fall back to that before asserting.
+ */
+export const expectSwipeToChangeBoard = async (
+  page: Page,
+  gameBoard: Locator,
+  swipe: Swipe,
+): Promise<void> => {
+  const before = await serializeBoard(gameBoard);
+
+  await swipe(page, gameBoard, "left");
+  await page.waitForTimeout(400);
+
+  if ((await serializeBoard(gameBoard)) === before) {
+    await swipe(page, gameBoard, "right");
+  }
+
+  await expect.poll(async () => serializeBoard(gameBoard)).not.toBe(before);
+};

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "Mobile Chrome",
+      use: { ...devices["Pixel 7"] },
+    },
   ],
   webServer: {
     command: "pnpm dev",


### PR DESCRIPTION
## Summary

Strengthens the E2E movement assertions so CI fails when swiping breaks, and adds a Mobile Chrome (Pixel 7) project that exercises the touch-driven swipe path.

## Replaced tautological assertions

- `expect(newScore).toBeGreaterThanOrEqual(initialScore)` (score is monotonic — it passed even with movement completely broken) → replaced with a **board-serialization check**: tiles are serialized into a sorted `row,col:label` string (`e2e-tests/utils.ts`), and a swipe must change that string. If the initial left swipe is a legal no-op (both starting tiles already in the leftmost column), the helper falls back to a right swipe, which is then guaranteed to move them — so the assertion is deterministic.
- The reset test now first performs a verifiably board-changing move, then asserts the board returns to exactly 2 starting tiles alongside `Score: 0`.
- The load test additionally asserts the 2 starting tiles are present.

## Mobile Chrome project

- `playwright.config.ts` gains a `Mobile Chrome` project (`devices["Pixel 7"]` — Chromium, so CI's existing `playwright install chromium` covers it).
- New `e2e-tests/mobile.spec.ts`: a touch-driven swipe via CDP `Input.dispatchTouchEvent` (real touch input, exercising the touch → pointer cascade `motion`'s `onPanEnd` pan handler depends on), asserting board change via the same serialization helper. Skipped on the desktop project.
- All existing tests (including the tile-alignment audit item) now also run at the Pixel 7 viewport via the second project.

## Test count

- Before: 4 tests × 1 project = 4 executed
- After: 5 tests × 2 projects = 9 executed + 1 skipped (touch test on desktop)
- Local full run: ~9s total, so the CI runtime impact is small.

## Test plan

- [x] `pnpm exec tsc --noEmit` / `pnpm exec eslint .` / `pnpm exec prettier --check .` pass
- [x] `pnpm exec vitest run` — 34 passed (unchanged)
- [x] `pnpm exec playwright test` — 9 passed, 1 skipped across both projects
