### PR TITLE
feat: persist game state and best score across sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,8 @@ import { GameBoard } from "./components/GameBoard";
 import { useGame2048 } from "./hooks/useGame2048";
 
 const App = () => {
-  const { tiles, score, gameOver, won, makeMove, resetGame } = useGame2048();
+  const { tiles, score, bestScore, gameOver, won, makeMove, resetGame } =
+    useGame2048();
 
   const handleSwipe = useCallback(
     (_event: PointerEvent | MouseEvent | TouchEvent, info: PanInfo) => {
@@ -35,9 +36,10 @@ const App = () => {
           </h1>
           <div
             aria-live="polite"
-            className="mb-2 text-[5vw] sm:mb-4 sm:text-xl md:text-2xl"
+            className="mb-2 flex justify-center gap-4 text-[5vw] sm:mb-4 sm:text-xl md:text-2xl"
           >
-            Score: {score}
+            <span>Score: {score}</span>
+            <span>Best: {bestScore}</span>
           </div>
         </div>
 

--- a/src/hooks/useGame2048.test.ts
+++ b/src/hooks/useGame2048.test.ts
@@ -1,9 +1,13 @@
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Board } from "../lib/game";
 import { createTile, GHOST_LIFETIME_MS, initializeBoard } from "../lib/game";
-import { useGame2048 } from "./useGame2048";
+import {
+  BEST_SCORE_STORAGE_KEY,
+  GAME_STATE_STORAGE_KEY,
+  useGame2048,
+} from "./useGame2048";
 
 // Keep the real game logic but make the starting board injectable, so each
 // test drives the hook from a known deterministic position instead of
@@ -26,6 +30,12 @@ const startFrom = (values: number[][]) => {
 
 const countTiles = (grid: number[][]) =>
   grid.flat().filter((value) => value !== 0).length;
+
+// Persistence is keyed on localStorage; isolate every test from the previous
+// one's saved state.
+beforeEach(() => {
+  localStorage.clear();
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -227,6 +237,163 @@ describe("useGame2048", () => {
       expect(result.current.won).toBe(false);
       expect(countTiles(result.current.grid)).toBe(2);
       expect(result.current.tiles.some((t) => t.isGhost === true)).toBe(false);
+    });
+  });
+
+  describe("persistence", () => {
+    it("starts bestScore at 0 when nothing is stored", () => {
+      const { result } = renderHook(() => useGame2048());
+
+      expect(result.current.bestScore).toBe(0);
+    });
+
+    it("restores a stored best score on init", () => {
+      localStorage.setItem(BEST_SCORE_STORAGE_KEY, "128");
+
+      const { result } = renderHook(() => useGame2048());
+
+      expect(result.current.bestScore).toBe(128);
+    });
+
+    it("raises bestScore to the new score and persists it", () => {
+      startFrom([
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { result } = renderHook(() => useGame2048());
+
+      act(() => {
+        result.current.makeMove("left");
+      });
+
+      expect(result.current.bestScore).toBe(4);
+      expect(localStorage.getItem(BEST_SCORE_STORAGE_KEY)).toBe("4");
+    });
+
+    it("keeps a higher stored best score when the current score stays below it", () => {
+      localStorage.setItem(BEST_SCORE_STORAGE_KEY, "100");
+      startFrom([
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { result } = renderHook(() => useGame2048());
+
+      act(() => {
+        result.current.makeMove("left");
+      });
+
+      expect(result.current.score).toBe(4);
+      expect(result.current.bestScore).toBe(100);
+      expect(localStorage.getItem(BEST_SCORE_STORAGE_KEY)).toBe("100");
+    });
+
+    it("preserves bestScore across resetGame while the score returns to 0", () => {
+      startFrom([
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { result } = renderHook(() => useGame2048());
+
+      act(() => {
+        result.current.makeMove("left");
+      });
+      act(() => {
+        result.current.resetGame();
+      });
+
+      expect(result.current.score).toBe(0);
+      expect(result.current.bestScore).toBe(4);
+      expect(localStorage.getItem(BEST_SCORE_STORAGE_KEY)).toBe("4");
+    });
+
+    it("restores board, score, and flags across a remount", () => {
+      startFrom([
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const first = renderHook(() => useGame2048());
+
+      act(() => {
+        first.result.current.makeMove("left");
+      });
+      const gridAfterMove = first.result.current.grid;
+      first.unmount();
+
+      const initCallsBeforeRemount = vi.mocked(initializeBoard).mock.calls
+        .length;
+      const second = renderHook(() => useGame2048());
+
+      expect(second.result.current.grid).toEqual(gridAfterMove);
+      expect(second.result.current.score).toBe(4);
+      expect(second.result.current.gameOver).toBe(false);
+      expect(second.result.current.won).toBe(false);
+      // The restore path must not generate a fresh board.
+      expect(vi.mocked(initializeBoard).mock.calls.length).toBe(
+        initCallsBeforeRemount,
+      );
+    });
+
+    it("clears the persisted game state on resetGame", () => {
+      startFrom([
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { result } = renderHook(() => useGame2048());
+
+      act(() => {
+        result.current.makeMove("left");
+      });
+      expect(localStorage.getItem(GAME_STATE_STORAGE_KEY)).not.toBeNull();
+
+      act(() => {
+        result.current.resetGame();
+      });
+
+      expect(localStorage.getItem(GAME_STATE_STORAGE_KEY)).toBeNull();
+    });
+
+    it("falls back to a fresh game and clears the entry on corrupt JSON", () => {
+      localStorage.setItem(GAME_STATE_STORAGE_KEY, "{ not json");
+
+      const { result } = renderHook(() => useGame2048());
+
+      expect(countTiles(result.current.grid)).toBe(2);
+      expect(result.current.score).toBe(0);
+      expect(localStorage.getItem(GAME_STATE_STORAGE_KEY)).toBeNull();
+    });
+
+    it("rejects a well-formed payload with the wrong shape or version", () => {
+      localStorage.setItem(
+        GAME_STATE_STORAGE_KEY,
+        JSON.stringify({
+          version: 999,
+          board: [],
+          score: 0,
+          gameOver: false,
+          won: false,
+        }),
+      );
+
+      const { result } = renderHook(() => useGame2048());
+
+      expect(countTiles(result.current.grid)).toBe(2);
+      expect(result.current.score).toBe(0);
+      expect(localStorage.getItem(GAME_STATE_STORAGE_KEY)).toBeNull();
     });
   });
 });

--- a/src/hooks/useGame2048.ts
+++ b/src/hooks/useGame2048.ts
@@ -1,27 +1,136 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { Board, Direction, TileState } from "../lib/game";
+import type { Board, Direction, SerializedBoard, TileState } from "../lib/game";
 import {
   addRandomTile,
   checkGameOver,
   checkWin,
   compareTileIds,
+  deserializeBoard,
   GHOST_LIFETIME_MS,
   initializeBoard,
+  isSerializedBoard,
   moveBoard,
+  serializeBoard,
 } from "../lib/game";
 
 export type { Direction, TileState } from "../lib/game";
 
+export const BEST_SCORE_STORAGE_KEY = "game2048:bestScore";
+export const GAME_STATE_STORAGE_KEY = "game2048:state";
+
+const GAME_STATE_VERSION = 1;
+
+interface PersistedGameState {
+  version: number;
+  board: SerializedBoard;
+  score: number;
+  gameOver: boolean;
+  won: boolean;
+}
+
+interface GameSnapshot {
+  board: Board;
+  score: number;
+  gameOver: boolean;
+  won: boolean;
+}
+
+// localStorage can be absent (some test environments) or throw (privacy mode,
+// quota exceeded) — persistence silently degrades to in-memory state.
+const safeGetItem = (key: string): string | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+const safeSetItem = (key: string, value: string) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Ignore — see note above.
+  }
+};
+
+const safeRemoveItem = (key: string) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // Ignore — see note above.
+  }
+};
+
+const isPersistedGameState = (value: unknown): value is PersistedGameState => {
+  if (typeof value !== "object" || value === null) return false;
+  const state = value as Record<string, unknown>;
+  return (
+    state.version === GAME_STATE_VERSION &&
+    typeof state.score === "number" &&
+    typeof state.gameOver === "boolean" &&
+    typeof state.won === "boolean" &&
+    isSerializedBoard(state.board)
+  );
+};
+
+const loadBestScore = (): number => {
+  const raw = safeGetItem(BEST_SCORE_STORAGE_KEY);
+  if (raw == null) return 0;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
+};
+
+const loadInitialSnapshot = (): GameSnapshot => {
+  const raw = safeGetItem(GAME_STATE_STORAGE_KEY);
+  if (raw != null) {
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (isPersistedGameState(parsed)) {
+        return {
+          board: deserializeBoard(parsed.board),
+          score: parsed.score,
+          gameOver: parsed.gameOver,
+          won: parsed.won,
+        };
+      }
+    } catch {
+      // Corrupt JSON — treat like any other invalid entry below.
+    }
+    safeRemoveItem(GAME_STATE_STORAGE_KEY);
+  }
+
+  return { board: initializeBoard(), score: 0, gameOver: false, won: false };
+};
+
+const saveGameState = (snapshot: GameSnapshot) => {
+  const state: PersistedGameState = {
+    version: GAME_STATE_VERSION,
+    board: serializeBoard(snapshot.board),
+    score: snapshot.score,
+    gameOver: snapshot.gameOver,
+    won: snapshot.won,
+  };
+  safeSetItem(GAME_STATE_STORAGE_KEY, JSON.stringify(state));
+};
+
 export const useGame2048 = () => {
-  const [board, setBoard] = useState<Board>(initializeBoard);
+  const [initialSnapshot] = useState(loadInitialSnapshot);
+  const [board, setBoard] = useState<Board>(initialSnapshot.board);
   const [ghosts, setGhosts] = useState<TileState[]>([]);
-  const [score, setScore] = useState(0);
-  const [gameOver, setGameOver] = useState(false);
-  const [won, setWon] = useState(false);
-  // Mirror of `board` so rapid successive moves (before React re-renders)
-  // always compute from the latest board without impure updater side effects.
+  const [score, setScore] = useState(initialSnapshot.score);
+  const [bestScore, setBestScore] = useState(loadBestScore);
+  const [gameOver, setGameOver] = useState(initialSnapshot.gameOver);
+  const [won, setWon] = useState(initialSnapshot.won);
+  // Mirrors of `board`/`score`/`bestScore` so rapid successive moves (before
+  // React re-renders) always compute from the latest values without impure
+  // updater side effects.
   const boardRef = useRef(board);
+  const scoreRef = useRef(score);
+  const bestScoreRef = useRef(bestScore);
   const ghostTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   useEffect(() => () => clearTimeout(ghostTimeoutRef.current), []);
@@ -41,7 +150,16 @@ export const useGame2048 = () => {
       const boardWithNewTile = addRandomTile(movedBoard);
       boardRef.current = boardWithNewTile;
       setBoard(boardWithNewTile);
-      setScore((prev) => prev + gainedScore);
+
+      const nextScore = scoreRef.current + gainedScore;
+      scoreRef.current = nextScore;
+      setScore(nextScore);
+
+      if (nextScore > bestScoreRef.current) {
+        bestScoreRef.current = nextScore;
+        setBestScore(nextScore);
+        safeSetItem(BEST_SCORE_STORAGE_KEY, String(nextScore));
+      }
 
       // Ghosts slide into their merge cell (hidden under the merged tile),
       // then get dropped once the slide animation has settled.
@@ -54,8 +172,17 @@ export const useGame2048 = () => {
         );
       }
 
-      if (checkWin(boardWithNewTile)) setWon(true);
-      else if (checkGameOver(boardWithNewTile)) setGameOver(true);
+      const nextWon = checkWin(boardWithNewTile);
+      const nextGameOver = !nextWon && checkGameOver(boardWithNewTile);
+      if (nextWon) setWon(true);
+      else if (nextGameOver) setGameOver(true);
+
+      saveGameState({
+        board: boardWithNewTile,
+        score: nextScore,
+        gameOver: nextGameOver,
+        won: nextWon,
+      });
     },
     [gameOver, won],
   );
@@ -64,11 +191,14 @@ export const useGame2048 = () => {
     clearTimeout(ghostTimeoutRef.current);
     const freshBoard = initializeBoard();
     boardRef.current = freshBoard;
+    scoreRef.current = 0;
     setBoard(freshBoard);
     setGhosts([]);
     setScore(0);
     setGameOver(false);
     setWon(false);
+    // Best score deliberately survives a reset.
+    safeRemoveItem(GAME_STATE_STORAGE_KEY);
   }, []);
 
   const grid = useMemo(
@@ -86,5 +216,5 @@ export const useGame2048 = () => {
     [board, ghosts],
   );
 
-  return { grid, tiles, score, gameOver, won, makeMove, resetGame };
+  return { grid, tiles, score, bestScore, gameOver, won, makeMove, resetGame };
 };

--- a/src/lib/game.ts
+++ b/src/lib/game.ts
@@ -209,3 +209,60 @@ export const initializeBoard = (): Board =>
 
 export const compareTileIds = (a: TileState, b: TileState) =>
   a.id.localeCompare(b.id, undefined, { numeric: true });
+
+export interface SerializedTile {
+  id: string;
+  value: number;
+  row: number;
+  col: number;
+}
+
+export type SerializedBoard = (SerializedTile | null)[][];
+
+export const serializeBoard = (board: Board): SerializedBoard =>
+  board.map((row) =>
+    row.map((cell) =>
+      cell
+        ? { id: cell.id, value: cell.value, row: cell.row, col: cell.col }
+        : null,
+    ),
+  );
+
+const isSerializedTile = (value: unknown): value is SerializedTile => {
+  if (typeof value !== "object" || value === null) return false;
+  const cell = value as Record<string, unknown>;
+  return (
+    typeof cell.id === "string" &&
+    typeof cell.value === "number" &&
+    typeof cell.row === "number" &&
+    typeof cell.col === "number"
+  );
+};
+
+export const isSerializedBoard = (value: unknown): value is SerializedBoard =>
+  Array.isArray(value) &&
+  value.length === GRID_SIZE &&
+  value.every(
+    (row) =>
+      Array.isArray(row) &&
+      row.length === GRID_SIZE &&
+      row.every((cell) => cell === null || isSerializedTile(cell)),
+  );
+
+const TILE_ID_PATTERN = /^tile-(\d+)$/;
+
+export const deserializeBoard = (serialized: SerializedBoard): Board => {
+  // Restored ids can outrank the fresh module counter after a reload; advance
+  // it so newly spawned tiles never collide with restored React keys.
+  for (const cell of serialized.flat()) {
+    const idNumber = cell ? TILE_ID_PATTERN.exec(cell.id)?.[1] : null;
+    if (idNumber != null)
+      tileIdCounter = Math.max(tileIdCounter, Number(idNumber));
+  }
+
+  return serialized.map((row) =>
+    row.map((cell) =>
+      cell ? createTile(cell.row, cell.col, cell.value, { id: cell.id }) : null,
+    ),
+  );
+};


### PR DESCRIPTION
## Summary

Adds localStorage persistence so a reload no longer loses progress — the classic 2048 must-have.

### What's persisted, and where

- `game2048:bestScore` — all-time best score (integer). Written whenever the current score exceeds it.
- `game2048:state` — versioned JSON snapshot `{ version: 1, board, score, gameOver, won }`, written after every move. `resetGame` clears this entry but keeps the best score.

Board serialization (`serializeBoard` / `deserializeBoard` / `isSerializedBoard`) lives in `src/lib/game.ts` so the shape is testable in isolation; `deserializeBoard` also advances the module tile-id counter past restored ids so newly spawned tiles can't collide with restored React keys.

### API additions

- `useGame2048` now returns `bestScore: number` (purely additive — existing fields unchanged).
- `App.tsx` shows `Best: {bestScore}` next to the score.

### Restore-on-reload UX

On mount the hook reads `game2048:state`; a valid snapshot restores the board, score, and game-over/won flags exactly where the player left off. Any invalid payload (corrupt JSON, wrong version, malformed board) is cleared and falls back to a fresh two-tile game — no crash. All localStorage access is wrapped in try/catch (privacy mode / quota / missing `localStorage`), degrading silently to in-memory state.

### Test coverage

New `persistence` suite in `src/hooks/useGame2048.test.ts` (8 cases): bestScore init/restore/raise/max-keep, bestScore survival across `resetGame`, full state restore across unmount+remount (without regenerating a fresh board), state cleared on reset, and fresh-init fallback for corrupt JSON and wrong-version payloads. `localStorage.clear()` runs before each test for isolation.

## Test plan

- [x] `pnpm exec tsc --noEmit`, `pnpm exec eslint .`, `pnpm exec vite build` pass
- [x] `pnpm exec vitest run` — 43 tests pass (incl. 8 new persistence cases)
- [x] `pnpm exec playwright test` — 4 E2E tests pass