### PR TITLE
feat: Keep Going after winning (2048 tile)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,21 @@ import { GameBoard } from "./components/GameBoard";
 import { useGame2048 } from "./hooks/useGame2048";
 
 const App = () => {
-  const { tiles, score, bestScore, gameOver, won, makeMove, resetGame } =
-    useGame2048();
+  const {
+    tiles,
+    score,
+    bestScore,
+    gameOver,
+    won,
+    keepPlaying,
+    makeMove,
+    resetGame,
+    startKeepPlaying,
+  } = useGame2048();
+
+  // Game over takes precedence: the board can fill up while keeping going
+  // after a win, and that must read as "Game Over!", not a second win.
+  const showWin = won && !keepPlaying && !gameOver;
 
   const handleSwipe = useCallback(
     (_event: PointerEvent | MouseEvent | TouchEvent, info: PanInfo) => {
@@ -56,7 +69,7 @@ const App = () => {
         </m.div>
 
         <AnimatePresence>
-          {(gameOver || won) && (
+          {(gameOver || showWin) && (
             <m.div
               key="game-state-overlay"
               aria-live="polite"
@@ -72,15 +85,26 @@ const App = () => {
               }}
             >
               <div className="mb-2 text-[6vw] font-bold sm:mb-4 sm:text-2xl md:text-3xl">
-                {won ? "You Win! 🎉" : "Game Over!"}
+                {showWin ? "You Win! 🎉" : "Game Over!"}
               </div>
-              <button
-                onClick={resetGame}
-                className="rounded-lg bg-blue-500 px-6 py-3 font-bold text-white transition-colors hover:bg-blue-700"
-                type="button"
-              >
-                New Game
-              </button>
+              <div className="flex justify-center gap-3">
+                {showWin && (
+                  <button
+                    onClick={startKeepPlaying}
+                    className="rounded-lg bg-orange-500 px-6 py-3 font-bold text-white transition-colors hover:bg-orange-700"
+                    type="button"
+                  >
+                    Keep Going
+                  </button>
+                )}
+                <button
+                  onClick={resetGame}
+                  className="rounded-lg bg-blue-500 px-6 py-3 font-bold text-white transition-colors hover:bg-blue-700"
+                  type="button"
+                >
+                  New Game
+                </button>
+              </div>
             </m.div>
           )}
         </AnimatePresence>

--- a/src/hooks/useGame2048.test.ts
+++ b/src/hooks/useGame2048.test.ts
@@ -2,7 +2,12 @@ import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Board } from "../lib/game";
-import { createTile, GHOST_LIFETIME_MS, initializeBoard } from "../lib/game";
+import {
+  createTile,
+  GHOST_LIFETIME_MS,
+  initializeBoard,
+  serializeBoard,
+} from "../lib/game";
 import {
   BEST_SCORE_STORAGE_KEY,
   GAME_STATE_STORAGE_KEY,
@@ -160,6 +165,147 @@ describe("useGame2048", () => {
         [4, 2, 4, 2],
       ]);
       expect(result.current.score).toBe(scoreBefore);
+    });
+  });
+
+  describe("keep going after a win", () => {
+    // Semantics choice: `won` stays true for the rest of the game once set;
+    // `keepPlaying` is a separate flag that unblocks moves (and, in the UI,
+    // dismisses the win overlay).
+    it("keeps won true and accepts moves again after startKeepPlaying", () => {
+      startFrom([
+        [1024, 1024, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { result } = renderHook(() => useGame2048());
+
+      act(() => {
+        result.current.makeMove("left");
+      });
+      expect(result.current.won).toBe(true);
+      expect(result.current.keepPlaying).toBe(false);
+
+      act(() => {
+        result.current.startKeepPlaying();
+      });
+      expect(result.current.won).toBe(true);
+      expect(result.current.keepPlaying).toBe(true);
+
+      const scoreBefore = result.current.score;
+      act(() => {
+        result.current.makeMove("right");
+      });
+
+      // The move went through: tiles slid right and a new tile spawned.
+      expect(countTiles(result.current.grid)).toBe(3);
+      expect(result.current.score).toBe(scoreBefore);
+    });
+
+    it("does not re-trigger the win state when another 2048 tile forms", () => {
+      startFrom([
+        [1024, 1024, 0, 0],
+        [512, 512, 0, 0],
+        [512, 512, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { result } = renderHook(() => useGame2048());
+
+      act(() => {
+        result.current.makeMove("left");
+      });
+      expect(result.current.won).toBe(true);
+
+      act(() => {
+        result.current.startKeepPlaying();
+      });
+
+      // Column 0 now holds 2048, 1024, 1024 — moving up forms a second 2048.
+      act(() => {
+        result.current.makeMove("up");
+      });
+
+      expect(result.current.grid[1]?.[0]).toBe(2048);
+      // Still in keep-playing mode (no second win overlay), moves continue.
+      expect(result.current.won).toBe(true);
+      expect(result.current.keepPlaying).toBe(true);
+      expect(result.current.gameOver).toBe(false);
+
+      const scoreBefore = result.current.score;
+      act(() => {
+        result.current.makeMove("up");
+      });
+      expect(result.current.score).toBe(scoreBefore + 4096);
+    });
+
+    it("clears keepPlaying on resetGame", () => {
+      startFrom([
+        [1024, 1024, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { result } = renderHook(() => useGame2048());
+
+      act(() => {
+        result.current.makeMove("left");
+      });
+      act(() => {
+        result.current.startKeepPlaying();
+      });
+      expect(result.current.keepPlaying).toBe(true);
+
+      act(() => {
+        result.current.resetGame();
+      });
+
+      expect(result.current.keepPlaying).toBe(false);
+      expect(result.current.won).toBe(false);
+    });
+
+    it("ignores startKeepPlaying before winning", () => {
+      startFrom([
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      const { result } = renderHook(() => useGame2048());
+
+      act(() => {
+        result.current.startKeepPlaying();
+      });
+
+      expect(result.current.keepPlaying).toBe(false);
+      expect(localStorage.getItem(GAME_STATE_STORAGE_KEY)).toBeNull();
+    });
+
+    it("restores keepPlaying across a remount", () => {
+      startFrom([
+        [1024, 1024, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const first = renderHook(() => useGame2048());
+
+      act(() => {
+        first.result.current.makeMove("left");
+      });
+      act(() => {
+        first.result.current.startKeepPlaying();
+      });
+      first.unmount();
+
+      const second = renderHook(() => useGame2048());
+
+      expect(second.result.current.won).toBe(true);
+      expect(second.result.current.keepPlaying).toBe(true);
     });
   });
 
@@ -365,6 +511,62 @@ describe("useGame2048", () => {
       });
 
       expect(localStorage.getItem(GAME_STATE_STORAGE_KEY)).toBeNull();
+    });
+
+    it("loads a v1 payload with keepPlaying defaulting to false", () => {
+      const storedBoard = boardFromValues([
+        [4, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      localStorage.setItem(
+        GAME_STATE_STORAGE_KEY,
+        JSON.stringify({
+          version: 1,
+          board: serializeBoard(storedBoard),
+          score: 42,
+          gameOver: false,
+          won: false,
+        }),
+      );
+
+      const { result } = renderHook(() => useGame2048());
+
+      // The v1 game survives the version bump instead of being wiped.
+      expect(result.current.score).toBe(42);
+      expect(countTiles(result.current.grid)).toBe(2);
+      expect(result.current.keepPlaying).toBe(false);
+    });
+
+    it("re-saves a restored v1 game as v2 on the next move", () => {
+      const storedBoard = boardFromValues([
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      localStorage.setItem(
+        GAME_STATE_STORAGE_KEY,
+        JSON.stringify({
+          version: 1,
+          board: serializeBoard(storedBoard),
+          score: 0,
+          gameOver: false,
+          won: false,
+        }),
+      );
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { result } = renderHook(() => useGame2048());
+
+      act(() => {
+        result.current.makeMove("left");
+      });
+
+      const raw = localStorage.getItem(GAME_STATE_STORAGE_KEY);
+      expect(raw).not.toBeNull();
+      const saved: unknown = JSON.parse(raw ?? "null");
+      expect(saved).toMatchObject({ version: 2, keepPlaying: false });
     });
 
     it("falls back to a fresh game and clears the entry on corrupt JSON", () => {

--- a/src/hooks/useGame2048.test.ts
+++ b/src/hooks/useGame2048.test.ts
@@ -477,8 +477,8 @@ describe("useGame2048", () => {
       const gridAfterMove = first.result.current.grid;
       first.unmount();
 
-      const initCallsBeforeRemount = vi.mocked(initializeBoard).mock.calls
-        .length;
+      const initCallsBeforeRemount =
+        vi.mocked(initializeBoard).mock.calls.length;
       const second = renderHook(() => useGame2048());
 
       expect(second.result.current.grid).toEqual(gridAfterMove);

--- a/src/hooks/useGame2048.ts
+++ b/src/hooks/useGame2048.ts
@@ -19,7 +19,7 @@ export type { Direction, TileState } from "../lib/game";
 export const BEST_SCORE_STORAGE_KEY = "game2048:bestScore";
 export const GAME_STATE_STORAGE_KEY = "game2048:state";
 
-const GAME_STATE_VERSION = 1;
+const GAME_STATE_VERSION = 2;
 
 interface PersistedGameState {
   version: number;
@@ -27,13 +27,20 @@ interface PersistedGameState {
   score: number;
   gameOver: boolean;
   won: boolean;
+  keepPlaying: boolean;
 }
+
+// v1 payloads predate keepPlaying; they load with keepPlaying defaulting to
+// false and get re-saved as v2 on the next save.
+type StoredGameState = Omit<PersistedGameState, "keepPlaying"> &
+  Partial<Pick<PersistedGameState, "keepPlaying">>;
 
 interface GameSnapshot {
   board: Board;
   score: number;
   gameOver: boolean;
   won: boolean;
+  keepPlaying: boolean;
 }
 
 // localStorage can be absent (some test environments) or throw (privacy mode,
@@ -65,11 +72,14 @@ const safeRemoveItem = (key: string) => {
   }
 };
 
-const isPersistedGameState = (value: unknown): value is PersistedGameState => {
+const isStoredGameState = (value: unknown): value is StoredGameState => {
   if (typeof value !== "object" || value === null) return false;
   const state = value as Record<string, unknown>;
+  const versionValid =
+    state.version === 1 ||
+    (state.version === 2 && typeof state.keepPlaying === "boolean");
   return (
-    state.version === GAME_STATE_VERSION &&
+    versionValid &&
     typeof state.score === "number" &&
     typeof state.gameOver === "boolean" &&
     typeof state.won === "boolean" &&
@@ -89,12 +99,13 @@ const loadInitialSnapshot = (): GameSnapshot => {
   if (raw != null) {
     try {
       const parsed: unknown = JSON.parse(raw);
-      if (isPersistedGameState(parsed)) {
+      if (isStoredGameState(parsed)) {
         return {
           board: deserializeBoard(parsed.board),
           score: parsed.score,
           gameOver: parsed.gameOver,
           won: parsed.won,
+          keepPlaying: parsed.keepPlaying ?? false,
         };
       }
     } catch {
@@ -103,7 +114,13 @@ const loadInitialSnapshot = (): GameSnapshot => {
     safeRemoveItem(GAME_STATE_STORAGE_KEY);
   }
 
-  return { board: initializeBoard(), score: 0, gameOver: false, won: false };
+  return {
+    board: initializeBoard(),
+    score: 0,
+    gameOver: false,
+    won: false,
+    keepPlaying: false,
+  };
 };
 
 const saveGameState = (snapshot: GameSnapshot) => {
@@ -113,6 +130,7 @@ const saveGameState = (snapshot: GameSnapshot) => {
     score: snapshot.score,
     gameOver: snapshot.gameOver,
     won: snapshot.won,
+    keepPlaying: snapshot.keepPlaying,
   };
   safeSetItem(GAME_STATE_STORAGE_KEY, JSON.stringify(state));
 };
@@ -125,6 +143,7 @@ export const useGame2048 = () => {
   const [bestScore, setBestScore] = useState(loadBestScore);
   const [gameOver, setGameOver] = useState(initialSnapshot.gameOver);
   const [won, setWon] = useState(initialSnapshot.won);
+  const [keepPlaying, setKeepPlaying] = useState(initialSnapshot.keepPlaying);
   // Mirrors of `board`/`score`/`bestScore` so rapid successive moves (before
   // React re-renders) always compute from the latest values without impure
   // updater side effects.
@@ -137,7 +156,7 @@ export const useGame2048 = () => {
 
   const makeMove = useCallback(
     (direction: Direction) => {
-      if (gameOver || won) return;
+      if (gameOver || (won && !keepPlaying)) return;
 
       const {
         board: movedBoard,
@@ -172,20 +191,36 @@ export const useGame2048 = () => {
         );
       }
 
-      const nextWon = checkWin(boardWithNewTile);
-      const nextGameOver = !nextWon && checkGameOver(boardWithNewTile);
-      if (nextWon) setWon(true);
+      // The win check fires at most once per game: after the first win the
+      // player either resets (state clears) or keeps going (later 2048+ tiles
+      // must not re-trigger the overlay).
+      const justWon = !won && checkWin(boardWithNewTile);
+      const nextGameOver = !justWon && checkGameOver(boardWithNewTile);
+      if (justWon) setWon(true);
       else if (nextGameOver) setGameOver(true);
 
       saveGameState({
         board: boardWithNewTile,
         score: nextScore,
         gameOver: nextGameOver,
-        won: nextWon,
+        won: won || justWon,
+        keepPlaying,
       });
     },
-    [gameOver, won],
+    [gameOver, won, keepPlaying],
   );
+
+  const startKeepPlaying = useCallback(() => {
+    if (!won || gameOver) return;
+    setKeepPlaying(true);
+    saveGameState({
+      board: boardRef.current,
+      score: scoreRef.current,
+      gameOver: false,
+      won: true,
+      keepPlaying: true,
+    });
+  }, [won, gameOver]);
 
   const resetGame = useCallback(() => {
     clearTimeout(ghostTimeoutRef.current);
@@ -197,6 +232,7 @@ export const useGame2048 = () => {
     setScore(0);
     setGameOver(false);
     setWon(false);
+    setKeepPlaying(false);
     // Best score deliberately survives a reset.
     safeRemoveItem(GAME_STATE_STORAGE_KEY);
   }, []);
@@ -216,5 +252,16 @@ export const useGame2048 = () => {
     [board, ghosts],
   );
 
-  return { grid, tiles, score, bestScore, gameOver, won, makeMove, resetGame };
+  return {
+    grid,
+    tiles,
+    score,
+    bestScore,
+    gameOver,
+    won,
+    keepPlaying,
+    makeMove,
+    resetGame,
+    startKeepPlaying,
+  };
 };


### PR DESCRIPTION
Reopened from #153 (auto-closed when the stack's base branch was deleted on merge of #152).

## Summary

Allow the player to continue after reaching 2048, matching the original 2048 UX.

- `keepPlaying` state added; when set, `makeMove` no longer early-returns on `won === true`
- Win overlay gains a "Keep Going" button (alongside "New Game")
- `checkWin` only fires once per game — subsequent 2048/4096/... tiles do not re-flash the overlay
- Game-over detection still applies during Keep Going mode
- Persists across reload: `game2048:state` payload bumped to `version: 2` with a `keepPlaying: boolean` field; v1 payload is treated as v2 with `keepPlaying: false` (no fresh init — existing users' games survive)

Test count: 43 → 50.

## Test plan

- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm exec eslint .` passes
- [x] `pnpm exec vitest run` — 50 tests pass
- [x] `pnpm exec vite build` passes
- [ ] Manual: reach 2048, click Keep Going, verify overlay dismisses and further moves work; reload and confirm no re-flash