### PR TITLE
feat: 1-step undo (Ctrl/Cmd+Z + button)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import type { PanInfo } from "motion/react";
 import { AnimatePresence, m } from "motion/react";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 
 import { GameBoard } from "./components/GameBoard";
 import { useGame2048 } from "./hooks/useGame2048";
@@ -13,10 +13,29 @@ const App = () => {
     gameOver,
     won,
     keepPlaying,
+    canUndo,
     makeMove,
+    undo,
     resetGame,
     startKeepPlaying,
   } = useGame2048();
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // Ctrl/Cmd+Z (without Shift, which conventionally means redo).
+      if (
+        (event.metaKey || event.ctrlKey) &&
+        !event.shiftKey &&
+        event.key.toLowerCase() === "z"
+      ) {
+        event.preventDefault();
+        undo();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [undo]);
 
   // Game over takes precedence: the board can fill up while keeping going
   // after a win, and that must read as "Game Over!", not a second win.
@@ -113,13 +132,23 @@ const App = () => {
           <p className="mb-2 text-[3.5vw] sm:text-base">
             Swipe or use arrow keys to play
           </p>
-          <button
-            onClick={resetGame}
-            className="rounded bg-gray-700 px-4 py-2 text-sm transition-colors hover:bg-gray-600"
-            type="button"
-          >
-            Reset Game
-          </button>
+          <div className="flex justify-center gap-3">
+            <button
+              onClick={undo}
+              disabled={!canUndo}
+              className="rounded bg-gray-700 px-4 py-2 text-sm transition-colors hover:bg-gray-600 disabled:opacity-40 disabled:hover:bg-gray-700"
+              type="button"
+            >
+              Undo
+            </button>
+            <button
+              onClick={resetGame}
+              className="rounded bg-gray-700 px-4 py-2 text-sm transition-colors hover:bg-gray-600"
+              type="button"
+            >
+              Reset Game
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/hooks/useGame2048.test.ts
+++ b/src/hooks/useGame2048.test.ts
@@ -309,6 +309,206 @@ describe("useGame2048", () => {
     });
   });
 
+  describe("1-step undo", () => {
+    it("starts with canUndo false on a fresh game", () => {
+      const { result } = renderHook(() => useGame2048());
+
+      expect(result.current.canUndo).toBe(false);
+    });
+
+    it("does not arm undo on a move that changes nothing", () => {
+      startFrom([
+        [2, 4, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      const { result } = renderHook(() => useGame2048());
+
+      act(() => {
+        result.current.makeMove("left");
+      });
+
+      expect(result.current.canUndo).toBe(false);
+    });
+
+    it("reverts board and score to the pre-move state and consumes the snapshot", () => {
+      startFrom([
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { result } = renderHook(() => useGame2048());
+      const gridBefore = result.current.grid;
+
+      act(() => {
+        result.current.makeMove("left");
+      });
+      expect(result.current.canUndo).toBe(true);
+      expect(result.current.score).toBe(4);
+
+      act(() => {
+        result.current.undo();
+      });
+
+      expect(result.current.grid).toEqual(gridBefore);
+      expect(result.current.score).toBe(0);
+      expect(result.current.canUndo).toBe(false);
+      expect(result.current.tiles.some((t) => t.isGhost === true)).toBe(false);
+    });
+
+    it("makes a second consecutive undo a no-op", () => {
+      startFrom([
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { result } = renderHook(() => useGame2048());
+
+      act(() => {
+        result.current.makeMove("left");
+      });
+      act(() => {
+        result.current.undo();
+      });
+      const gridAfterUndo = result.current.grid;
+
+      act(() => {
+        result.current.undo();
+      });
+
+      expect(result.current.grid).toEqual(gridAfterUndo);
+      expect(result.current.score).toBe(0);
+      expect(result.current.canUndo).toBe(false);
+    });
+
+    it("arms a fresh snapshot on the next move after an undo", () => {
+      startFrom([
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { result } = renderHook(() => useGame2048());
+
+      act(() => {
+        result.current.makeMove("left");
+      });
+      act(() => {
+        result.current.undo();
+      });
+      act(() => {
+        result.current.makeMove("left");
+      });
+
+      expect(result.current.canUndo).toBe(true);
+      expect(result.current.score).toBe(4);
+    });
+
+    it("clears canUndo on resetGame", () => {
+      startFrom([
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { result } = renderHook(() => useGame2048());
+
+      act(() => {
+        result.current.makeMove("left");
+      });
+      expect(result.current.canUndo).toBe(true);
+
+      act(() => {
+        result.current.resetGame();
+      });
+
+      expect(result.current.canUndo).toBe(false);
+    });
+
+    it("reverts a win back to won: false", () => {
+      startFrom([
+        [1024, 1024, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const { result } = renderHook(() => useGame2048());
+
+      act(() => {
+        result.current.makeMove("left");
+      });
+      expect(result.current.won).toBe(true);
+
+      act(() => {
+        result.current.undo();
+      });
+
+      expect(result.current.won).toBe(false);
+      expect(result.current.score).toBe(0);
+      // Moves are accepted again after the win is reverted.
+      act(() => {
+        result.current.makeMove("left");
+      });
+      expect(result.current.won).toBe(true);
+    });
+
+    it("does not survive a reload: canUndo is false after a remount", () => {
+      startFrom([
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const first = renderHook(() => useGame2048());
+
+      act(() => {
+        first.result.current.makeMove("left");
+      });
+      expect(first.result.current.canUndo).toBe(true);
+      first.unmount();
+
+      const second = renderHook(() => useGame2048());
+
+      // The game state itself is restored, but the undo snapshot is not.
+      expect(second.result.current.score).toBe(4);
+      expect(second.result.current.canUndo).toBe(false);
+    });
+
+    it("persists the reverted state so a reload after undo restores it", () => {
+      startFrom([
+        [2, 2, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+      ]);
+      vi.spyOn(Math, "random").mockReturnValue(0);
+      const first = renderHook(() => useGame2048());
+      const gridBefore = first.result.current.grid;
+
+      act(() => {
+        first.result.current.makeMove("left");
+      });
+      act(() => {
+        first.result.current.undo();
+      });
+      first.unmount();
+
+      const second = renderHook(() => useGame2048());
+
+      expect(second.result.current.grid).toEqual(gridBefore);
+      expect(second.result.current.score).toBe(0);
+    });
+  });
+
   describe("tiles and ghost handling", () => {
     it("keeps the surviving id on the merged tile and places the ghost in the merge cell", () => {
       startFrom([

--- a/src/hooks/useGame2048.ts
+++ b/src/hooks/useGame2048.ts
@@ -43,6 +43,16 @@ interface GameSnapshot {
   keepPlaying: boolean;
 }
 
+// Pre-move state captured for the 1-step undo. Deliberately NOT persisted:
+// undo is a session-scoped affordance, so canUndo is always false after a
+// reload. Ghosts are dropped on undo rather than snapshotted.
+interface UndoSnapshot {
+  board: Board;
+  score: number;
+  gameOver: boolean;
+  won: boolean;
+}
+
 // localStorage can be absent (some test environments) or throw (privacy mode,
 // quota exceeded) — persistence silently degrades to in-memory state.
 const safeGetItem = (key: string): string | null => {
@@ -151,6 +161,10 @@ export const useGame2048 = () => {
   const scoreRef = useRef(score);
   const bestScoreRef = useRef(bestScore);
   const ghostTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  // The snapshot lives in a ref (only consumed inside callbacks); canUndo is
+  // the render-facing mirror the UI reacts to.
+  const undoSnapshotRef = useRef<UndoSnapshot | null>(null);
+  const [canUndo, setCanUndo] = useState(false);
 
   useEffect(() => () => clearTimeout(ghostTimeoutRef.current), []);
 
@@ -165,6 +179,14 @@ export const useGame2048 = () => {
         moved,
       } = moveBoard(boardRef.current, direction);
       if (!moved) return;
+
+      undoSnapshotRef.current = {
+        board: boardRef.current,
+        score: scoreRef.current,
+        gameOver,
+        won,
+      };
+      setCanUndo(true);
 
       const boardWithNewTile = addRandomTile(movedBoard);
       boardRef.current = boardWithNewTile;
@@ -210,6 +232,33 @@ export const useGame2048 = () => {
     [gameOver, won, keepPlaying],
   );
 
+  const undo = useCallback(() => {
+    const snapshot = undoSnapshotRef.current;
+    if (snapshot == null) return;
+    // The snapshot is consumed: undoing twice in a row is a no-op until the
+    // next successful move produces a fresh one.
+    undoSnapshotRef.current = null;
+    setCanUndo(false);
+
+    clearTimeout(ghostTimeoutRef.current);
+    boardRef.current = snapshot.board;
+    scoreRef.current = snapshot.score;
+    setBoard(snapshot.board);
+    setScore(snapshot.score);
+    setGhosts([]);
+    setGameOver(snapshot.gameOver);
+    setWon(snapshot.won);
+    // bestScore deliberately survives an undo.
+
+    saveGameState({
+      board: snapshot.board,
+      score: snapshot.score,
+      gameOver: snapshot.gameOver,
+      won: snapshot.won,
+      keepPlaying,
+    });
+  }, [keepPlaying]);
+
   const startKeepPlaying = useCallback(() => {
     if (!won || gameOver) return;
     setKeepPlaying(true);
@@ -224,6 +273,8 @@ export const useGame2048 = () => {
 
   const resetGame = useCallback(() => {
     clearTimeout(ghostTimeoutRef.current);
+    undoSnapshotRef.current = null;
+    setCanUndo(false);
     const freshBoard = initializeBoard();
     boardRef.current = freshBoard;
     scoreRef.current = 0;
@@ -260,7 +311,9 @@ export const useGame2048 = () => {
     gameOver,
     won,
     keepPlaying,
+    canUndo,
     makeMove,
+    undo,
     resetGame,
     startKeepPlaying,
   };


### PR DESCRIPTION
Reopened from #154 (auto-closed when the stack's base branch was deleted on merge of #155).

## Summary

1-step Undo — the player can revert the last move once, valuable for mistap recovery on mobile.

- Snapshot the board + score + won/gameOver flags **before** each valid move; store in a ref (session-scoped, not persisted).
- `undo()` restores the snapshot, clears ghosts, and reverts `won`/`gameOver` transitions the move caused.
- Snapshot is consumed on use — no double-undo. The next `makeMove` re-arms it.
- Undo that reverts a win flips `won` back to `false` so the player can keep playing.
- `bestScore` is NOT reverted (best is all-time).
- `resetGame` clears the snapshot.

## API additions

- `undo: () => void`
- `canUndo: boolean`

## UI

- `Undo` button next to `Reset Game` (matches existing style, disabled + gray when `!canUndo`).
- Keyboard shortcut: **Ctrl/Cmd+Z** (Shift+Z ignored to respect the browser's redo convention). `preventDefault` on to avoid browser undo.

## Persistence

- Snapshot is NOT persisted (session-scoped). After reload, `canUndo: false`.

Test count: 50 → 59.

## Test plan

- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm exec eslint .` passes
- [x] `pnpm exec vitest run` — 59 tests pass
- [x] `pnpm exec vite build` passes
- [ ] Manual: make a move → Undo button becomes active → click it → board reverts, button grays out
- [ ] Manual: Ctrl/Cmd+Z shortcut works from anywhere on the page
- [ ] Manual: reach 2048 → Undo → win overlay dismisses and further moves work