### PR TITLE
chore(ci): pin GitHub Actions to commit SHA for supply-chain security

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,6 +4,6 @@ description: "Setup Node.js environment, pnpm, cache, and install dependencies"
 runs:
   using: "composite"
   steps:
-    - uses: jdx/mise-action@v4
+    - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
     - run: pnpm install --frozen-lockfile
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: ./.github/actions/setup
       - run: pnpm lint
 
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: ./.github/actions/setup
       - run: pnpm test
 
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: ./.github/actions/setup
 
       - name: Get Playwright version
@@ -40,7 +40,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,33 +22,33 @@ jobs:
       name: ${{ github.ref_name == 'main' && 'production' || 'preview' }}
       url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
-      - uses: marocchino/sticky-pull-request-comment@v3.0.5
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         name: Show wip message in sticky comment
         with:
           message: "Version Preview URL: ⏳deployment is in progress..."
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: ./.github/actions/setup
 
-      - uses: nemolize/set-wrangler-name@v1
+      - uses: nemolize/set-wrangler-name@3630486c8e8402077ed7a3cb45c3576732777048 # v1
 
       - run: pnpm run build
 
       - id: deploy
         name: Deploy
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           command: ${{ github.event_name == 'push' && 'deploy' || 'versions upload' }}
 
       - if: ${{ github.event_name == 'pull_request' }}
         name: Show version preview URL in sticky comment
-        uses: marocchino/sticky-pull-request-comment@v3.0.5
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           message: "Version Preview URL: ${{ steps.deploy.outputs.deployment-url }}"
 
       - if: failure()
         name: Show error message in sticky comment
-        uses: marocchino/sticky-pull-request-comment@v3.0.5
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           message: "Version Preview URL: ❌deployment failed."


### PR DESCRIPTION
## Why

Third-party GitHub Actions were referenced by mutable version tags (`@v5`, `@v3`, etc.). A tag can be force-moved or a compromised maintainer can republish it to point at malicious code — which would then run inside our CI/CD pipeline with access to secrets (`CLOUDFLARE_API_TOKEN`, deploy credentials). Pinning each action to an immutable commit SHA closes this supply-chain vector: the exact reviewed code is what runs, and a moved tag can no longer change it.

## What

Replaced mutable tags with the commit SHA each tag currently resolves to, keeping the human-readable version as a trailing comment (Renovate reads this comment to keep the pins up to date).

| Action | Pinned SHA | Version |
|---|---|---|
| `actions/checkout` | `93cb6ef` | v5.0.1 |
| `actions/cache` | `0057852` | v4.3.0 |
| `jdx/mise-action` | `e6a8b39` | v4.2.0 |
| `marocchino/sticky-pull-request-comment` | `5770ad5` | v3.0.5 |
| `nemolize/set-wrangler-name` | `3630486` | v1 |
| `cloudflare/wrangler-action` | `9acf94a` | v3.15.0 |

The local composite action (`./.github/actions/setup`) is not pinned — it lives in this repo and carries no external supply-chain risk.

## Test plan

Nothing beyond CI — the Lint / Test / E2ETests / Deploy jobs exercise every pinned action end-to-end. Green CI confirms all SHAs resolve and the actions run unchanged.