### PR TITLE
fix: gate deploy cancellation to non-main refs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,16 +8,22 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Queue production deploys so a rapid second push cannot cancel an
+  # in-flight deploy; preview uploads are safe to supersede.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   Deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # `pull-requests: write` is needed only by the sticky-comment steps, which
+    # are themselves gated on `github.event_name == 'pull_request'`.
+    permissions:
+      contents: read
+      pull-requests: write
     environment:
       name: ${{ github.ref_name == 'main' && 'production' || 'preview' }}
       url: ${{ steps.deploy.outputs.deployment-url }}


### PR DESCRIPTION
## Summary

Propagates two deploy-workflow fixes from the `web-app-template` this repository was created from. Tracked in nemolize/web-app-template#359; the fixes themselves are nemolize/web-app-template#358.

## Changes

**`cancel-in-progress` could cancel an in-flight production deploy**

`cancel-in-progress: true` applied to `main` as well, so a rapid second push could cancel a deploy partway through. A cancelled deploy is not a no-op: the upload and the activation are separate API calls, so stopping between them can leave a state that matches no commit, and nothing re-runs to correct it. Now gated to non-`main` refs — production deploys queue instead of cancelling, while preview uploads still supersede each other.

**`pull-requests: write` was granted workflow-wide**

Only the sticky-comment steps need it, and those are already gated on `github.event_name == 'pull_request'`. Moved to the `Deploy` job.

## Impact

CI/CD configuration only. No application code changes. Consecutive pushes to `main` now queue rather than cancel, so the last push still wins — it just waits instead of interrupting.

## Test plan

- [x] `actionlint` passes
