### PR TITLE
chore(renovate): let timestamp-less registries satisfy minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>nemolize/renovate-config"]
+  "extends": ["local>nemolize/renovate-config"],
+  "packageRules": [
+    {
+      "description": "mcr.microsoft.com serves no release timestamps, and the default timestamp-required behaviour treats a missing one as never old enough — so minimumReleaseAge holds these back indefinitely rather than for its stated window. That silently strands the Playwright image outside the group it shares with the npm packages, which is what keeps the E2E version-parity guard failing.",
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["mcr.microsoft.com/**"],
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
+    }
+  ]
 }


### PR DESCRIPTION
Unblocks the Playwright update, which has been stuck since the group rule that was meant to fix it landed.

## The problem

The shared preset groups the Playwright npm packages with the container image that ships their browsers, because the image bundles browsers built for one Playwright version and a split update breaks E2E. That grouping works — the group PR exists and is named after it.

The image still never joins it. `mcr.microsoft.com` serves no release timestamps, and `minimumReleaseAge`'s default behaviour treats a missing timestamp as "not yet old enough". So the hold is not the three days it names — it is indefinite. The npm packages carry timestamps and move; the image is filtered out and stays behind.

The result is a group PR bumping only the packages, which then fails the E2E job's assertion that the image ships the Playwright version we depend on. That assertion is doing its job; the version skew is real.

## The fix

Scope `timestamp-optional` to docker-sourced `mcr.microsoft.com` dependencies. Aging stays active for every other source, and it resumes here on its own if the registry ever starts returning timestamps — which is why this is preferred over disabling `minimumReleaseAge` for the matcher.

This is repository-scoped on purpose: the same symptom is visible upstream in the template, so if this works the rule belongs in the shared preset rather than in each repository. Verifying it here first is cheaper than rolling it out blind.

## Test plan

CI cannot exercise this — the behaviour only appears when Renovate next runs.

- [x] After merge, rebase the Playwright PR and confirm its diff includes the workflow's image tag alongside the lockfile
- [x] Confirm the E2E job's version-parity assertion passes on that rebased PR
- [x] If both hold, promote the rule to the shared preset — done in nemolize/renovate-config#5; the local copy was then removed in #191

<!-- coverage-start -->
### Coverage

| | metric | % | covered |
| --- | --- | --- | --- |
| 🟠 | statements | 84.53% | 257/304 |
| 🔴 | branches | 72.72% | 128/176 |
| 🟠 | functions | 81.25% | 52/64 |
| 🟠 | lines | 84.44% | 228/270 |

🟢 90% and above · 🟠 80–89% · 🔴 below 80%
<!-- coverage-end -->

