### PR TITLE
chore(renovate): drop the local override now the preset carries it

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>nemolize/renovate-config"],
-  "packageRules": [
-    {
-      "description": "mcr.microsoft.com serves no release timestamps, and the default timestamp-required behaviour treats a missing one as never old enough — so minimumReleaseAge holds these back indefinitely rather than for its stated window. That silently strands the Playwright image outside the group it shares with the npm packages, which is what keeps the E2E version-parity guard failing.",
-      "matchDatasources": ["docker"],
-      "matchDepNames": ["mcr.microsoft.com/**"],
-      "minimumReleaseAgeBehaviour": "timestamp-optional"
-    }
-  ]
+  "extends": ["local>nemolize/renovate-config"]
 }


### PR DESCRIPTION
Follow-up to #188, which is where this rule was first verified.

The `timestamp-optional` rule was put here deliberately, to prove it worked before rolling it out. It has since landed in the shared preset (nemolize/renovate-config#5), with the matcher widened to cover `ghcr.io` as well, so this repository no longer needs its own copy.

Leaving it would be worse than merely redundant: it matches the same dependencies as the shared rule, so a later change to the shared one would silently fail to reach this repository — the exact class of drift that made the original problem take a week to notice.

Verified the preset's default branch carries the rule and that its matcher covers everything this file matched, before removing it.

## Test plan

Nothing beyond CI. The rule's behaviour was already verified in #188; this only removes a duplicate of it.

<!-- coverage-start -->
### Coverage

| | metric | % | covered |
| --- | --- | --- | --- |
| 🟠 | statements | 84.53% | 257/304 |
| 🔴 | branches | 72.72% | 128/176 |
| 🟠 | functions | 81.25% | 52/64 |
| 🟠 | lines | 84.44% | 228/270 |

🟢 90% and above · 🟠 80–89% · 🔴 below 80%
<!-- coverage-end -->