### PR TITLE
ci: follow upsert into the shared actions monorepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - if: ${{ !cancelled() && (steps.test.outcome == 'success' || steps.test.outcome == 'failure') }}
         name: Write the coverage report into the PR description
-        uses: nemolize/upsert@173e49a4822af386e19526114249b47aa2888f09 # v1.0.1
+        uses: nemolize/actions/upsert@77ba465744c758cc704be356f9fbc48d152baa4c # v1.1.0
         with:
           marker: coverage
           body: ${{ steps.table.outputs.markdown }}


### PR DESCRIPTION
## What

Repins the coverage-report step from `nemolize/upsert` to
`nemolize/actions/upsert`, where the action now lives.

## Why

`upsert` moved into the shared actions monorepo alongside `setup`, so it is
released under the tag covering that repository rather than carrying a release
cycle of its own. Inputs and outputs are unchanged — this is a pin change and
nothing else.

`v1.1.0` also fixes two defects the standalone repository shipped:

- Content carrying the block's own marker on a line of its own closed the block
  early, so the remainder landed outside it and was appended again on every
  later run — the description grew each time and never recovered.
- An explicit `repository` input reused the triggering event's endpoint for a
  target in another repository, hitting the wrong endpoint and demanding the
  wrong permission. This workflow does not pass `repository`, so it was not
  exposed to that one.

## Test plan

The coverage step runs on this PR, so a green run that writes the coverage block
into this description is the verification.

- [x] Coverage block appears in this PR's description — written by the migrated action

<!-- coverage-start -->
### Coverage

| | metric | % | covered |
| --- | --- | --- | --- |
| 🟠 | statements | 84.53% | 257/304 |
| 🔴 | branches | 72.72% | 128/176 |
| 🟠 | functions | 81.25% | 52/64 |
| 🟠 | lines | 84.44% | 228/270 |

🟢 90% and above · 🟠 80–89% · 🔴 below 80%
<!-- coverage-end -->
